### PR TITLE
Release 1.19.0: security, new features, string_pattern 2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
+Gemfile.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
   - 3.0
   - 3.1
+  - 3.2
+  - 3.3
   - ruby-head
 branches:
   except:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.19.0] - 2025-02-11
+
+### Compatibility
+
+- **Ruby**: Gemspec now sets `required_ruby_version = '>= 3.0'`. Ruby 2.x is no longer supported.
+- **string_pattern**: Runtime dependency is `~> 2.4` (was `~> 2.3`). Upgrade to string_pattern 2.4+ when upgrading to nice_hash 1.19.
+- **:uuid**: The symbol `:uuid` as a pattern value now generates/validates a UUID v4 string (string_pattern 2.4). If you previously used `:uuid` as a literal value (expecting the symbol or the string `"uuid"`), that behavior has changed.
+
+All other changes are backwards compatible: same method signatures, new optional parameters (`seed:`, etc.), and new methods only added.
+
+### Security
+
+- Replaced `eval` in `NiceHash.set_nested` and `NiceHash.delete_nested` with iterative key traversal to prevent code injection when keys or values come from untrusted input.
+
+### Added
+
+- `respond_to_missing?` for `Hash` and `Array` so `respond_to?(:key_name)` works correctly for method-style key access.
+- **`generate_n(n)`**: Generate n different hashes in one call (`NiceHash.generate_n(pattern_hash, n, select_hash_key, expected_errors: [])` and `hash.generate_n(n, ...)` / `hash.gen_n(n, ...)`).
+- **`diff(expected, actual)`**: Compare two hashes and get differences with dot-notation paths (`NiceHash.diff` and `hash.diff(other)`).
+- **`flatten_keys`** / **`unflatten_keys`**: Convert between nested hashes and flat hashes with dot-notation keys (`NiceHash.flatten_keys`, `NiceHash.unflatten_keys`, `hash.flatten_keys`, `hash.unflatten_keys`).
+- **string_pattern 2.4**: Pattern value `:uuid` generates/validates UUID v4; `generate` / `generate_n` accept optional `seed:` for reproducible output.
+- Specs for set_nested/delete_nested (including injection-safe behavior), transtring, get_all_keys, String#json, Array#json, nice_filter edge cases, respond_to? for Hash/Array, and the new features above.
+
+### Fixed
+
+- `NiceHash.deep_clone` now correctly handles non-Array/non-Hash values by returning a shallow clone explicitly instead of relying on a no-op else branch.
+
+### Changed
+
+- Gemspec: `required_ruby_version` set to `>= 3.0`.
+- CI: Travis now includes Ruby 3.2 and 3.3.
+
+## [1.18.7] - (previous releases)
+
+See git history for earlier changes.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To use nice_hash on Http connections take a look at nice_http gem: https://githu
 
 ## Table of contents
 - [Installation](#installation)
+- [Configuration](#configuration)
 - [Usage](#usage)
   * [How to access the different keys](#how-to-access-the-different-keys)
   * [Change all values on the keys we specified](#change-all-values-on-the-keys-we-specified)
@@ -64,9 +65,34 @@ Or install it yourself as:
 
     $ gem install nice_hash
 
+## Configuration
+
+Set these constants **before** `require 'nice_hash'` if you need to change default behavior:
+
+- **`SP_ADD_TO_RUBY`** (default: `true`): When `true`, the gem adds methods to core classes (`Hash`, `Array`, `String`, `Object`, `Date`, `Time`, etc.). Set to `false` to avoid patching core classes and use only `NiceHash` class methods.
+- **`SP_COMPARE_NUMBERS_AS_STRINGS`** (default: `true`): When `true`, `String#==` is overridden so that strings are compared with numbers as strings (e.g. `'300' == 300` and `'' == nil`). Set to `false` if this causes issues with other gems (e.g. some versions of `net/ldap`).
+
+When using **string_pattern** 2.4+, you can also set **`StringPattern.logger`** (e.g. `Logger.new($stderr)`) to redirect generation/validation messages, and **`StringPattern.raise_on_error = true`** to raise on invalid patterns or impossible generation instead of returning empty strings.
+
+Example:
+
+```ruby
+SP_COMPARE_NUMBERS_AS_STRINGS = false
+require 'nice_hash'
+```
+
 ## Usage
 
-Remember!! To generate the strings following a pattern take a look at the documentation for string_pattern gem: https://github.com/MarioRuiz/string_pattern. You can also generate Spanish or English words. We added support for generating strings from regular expressions but it is only working for the ´generate´ method, use it with caution since it is still on an early stage of development. All you have to do is to add to a key the value as a Regular expression, for example the key uuid in here will generate a random value like this: "E0BDE5B5-A738-49E6-83C1-9D1FFB313788"
+Remember!! To generate the strings following a pattern take a look at the documentation for string_pattern gem: https://github.com/MarioRuiz/string_pattern. You can also generate Spanish or English words. We added support for generating strings from regular expressions but it is only working for the ´generate´ method, use it with caution since it is still on an early stage of development.
+
+For **UUID v4** you can use the shorthand `:uuid` (requires string_pattern 2.4+):
+
+```ruby
+my_hash = { id: :uuid, key: "Wsdf88888", doomId: :"10:N" }
+# id will be like "550e8400-e29b-41d4-a716-446655440000"
+```
+
+Or use a Regular expression for custom formats:
 
 ```ruby
 my_hash = { 

--- a/docs/STRING_PATTERN_2.4_INTEGRATION.md
+++ b/docs/STRING_PATTERN_2.4_INTEGRATION.md
@@ -1,0 +1,46 @@
+# string_pattern v2.4.0 – integration with NiceHash
+
+Summary of 2.4.0 features and how NiceHash uses or could use them.
+
+## New in string_pattern 2.4.0
+
+| Feature | Description |
+|--------|--------------|
+| **StringPattern.valid_email?** | Email format validation (same rules as `@` pattern). |
+| **StringPattern.analyze** | Returns a Pattern struct (min_length, max_length, symbol_type, etc.); `silent: true` avoids logging. NiceHash already uses `analyze` in pattern_fields, select_key, generate, validate. |
+| **StringPattern.uuid** | Generates a random UUID v4. |
+| **StringPattern.valid_uuid?** | Validates UUID v4 format. |
+| **seed:** | Reproducible generation: `"10:N".gen(seed: 42)`. |
+| **StringPattern.sample(pattern, n)** | Generates up to `n` distinct strings (temporary dont_repeat). |
+| **StringPattern.valid?** | Boolean validation (no full error list). |
+| **raise_on_error** / **logger** | `StringPattern.raise_on_error = true` raises on invalid pattern / impossible generation; `StringPattern.logger` redirects messages. |
+| **block_list as Proc** | Custom block with a lambda. |
+
+---
+
+## Implemented in NiceHash
+
+1. **Reproducible generation (seed)**  
+   `generate` and `generate_n` accept `seed:` and pass it through to `StringPattern.generate`, so `my_hash.generate(:correct, seed: 42)` and `my_hash.generate_n(5, :correct, seed: 123)` are reproducible.
+
+2. **UUID shorthand**  
+   In a pattern hash, use `id: :uuid` (or any key with value `:uuid`) to generate a UUID v4. In `validate`, `:uuid` is accepted and validated with `StringPattern.valid_uuid?`. In `compare_structure`, patterns hash can use `:uuid` to check UUID format.
+
+3. **Configuration**  
+   README documents that `StringPattern.logger` and `StringPattern.raise_on_error` affect generation/validation when using NiceHash.
+
+---
+
+## Possible future use
+
+- **StringPattern.valid_email?**  
+  Email validation is already covered by the `@` pattern in validate/generate. Could add a shorthand `email: true` or use `valid_email?` in compare_structure patterns for consistency.
+
+- **StringPattern.sample**  
+  When generating an array of one pattern (e.g. `user_names: [:'3-10:L']`), could call `StringPattern.sample(pattern, n)` to get distinct values when `expected_errors` is empty.
+
+- **StringPattern.valid?**  
+  In `compare_structure`, when checking a single pattern we could use `StringPattern.valid?` instead of `validate(...).empty?` for a small optimization.
+
+- **Pattern metadata**  
+  Use `StringPattern.analyze` to expose something like `pattern_fields_with_metadata` (min/max length, symbol_type) for docs or tooling.

--- a/lib/nice/hash/add_to_ruby.rb
+++ b/lib/nice/hash/add_to_ruby.rb
@@ -166,6 +166,16 @@ class Hash
   #   my_hash.city="Paris"
   #   my_hash.products[1].price.wrong="AAAAA"
   ###########################################################################
+  def respond_to_missing?(method_name, include_private = false)
+    sym = (method_name.to_s[0] == "_" ? method_name.to_s[1..-1].to_sym : method_name)
+    return true if key?(sym) || key?(sym.to_s)
+    if method_name.to_s[-1] == "="
+      setter_key = method_name.to_s.chop
+      return true if key?(setter_key) || key?(setter_key.to_sym)
+    end
+    false
+  end
+
   def method_missing(m, *arguments, &block)
     m = m[1..-1].to_sym if m[0] == "_"
     if key?(m)
@@ -229,6 +239,13 @@ class Hash
   ###########################################################################
   def generate(select_hash_key = nil, expected_errors: [], **synonyms)
     NiceHash.generate(self, select_hash_key, expected_errors: expected_errors, **synonyms)
+  end
+
+  ###########################################################################
+  # Generates n different hashes from the same pattern. More info: NiceHash.generate_n
+  ###########################################################################
+  def generate_n(n, select_hash_key = nil, expected_errors: [], **synonyms)
+    NiceHash.generate_n(self, n, select_hash_key, expected_errors: expected_errors, **synonyms)
   end
 
   ###########################################################################
@@ -299,6 +316,28 @@ class Hash
   end
 
   ###########################################################################
+  # Compares with another hash and returns differences with dot-notation paths.
+  # More info: NiceHash.diff
+  ###########################################################################
+  def diff(other)
+    NiceHash.diff(self, other)
+  end
+
+  ###########################################################################
+  # Flattens the hash to dot-notation keys. More info: NiceHash.flatten_keys
+  ###########################################################################
+  def flatten_keys
+    NiceHash.flatten_keys(self)
+  end
+
+  ###########################################################################
+  # Unflattens a hash with dot-notation keys into nested hash. More info: NiceHash.unflatten_keys
+  ###########################################################################
+  def unflatten_keys
+    NiceHash.unflatten_keys(self)
+  end
+
+  ###########################################################################
   # Merging multi-dimensional hashes
   ###########################################################################
   def nice_merge(hash = nil, return_self = false)
@@ -322,6 +361,7 @@ class Hash
   end
 
   alias gen generate
+  alias gen_n generate_n
   alias val validate
   alias patterns pattern_fields
   alias nice_copy deep_copy
@@ -365,6 +405,11 @@ class Array
   #   my_array.city
   #   my_array._name
   ###########################################################################
+  def respond_to_missing?(method_name, include_private = false)
+    sym = (method_name.to_s[0] == "_" ? method_name.to_s[1..-1].to_sym : method_name)
+    any? { |elem| elem.is_a?(Hash) && (elem.key?(sym) || elem.key?(sym.to_s)) }
+  end
+
   def method_missing(m, *arguments, &block)
     m = m[1..-1].to_sym if m[0] == "_"
     array = []

--- a/lib/nice/hash/deep_clone.rb
+++ b/lib/nice/hash/deep_clone.rb
@@ -21,6 +21,7 @@ class NiceHash
   #    #>{:user=>{:address=>{:city=>"Madrid", :country=>"Spain"}, :name=>"Peter", :age=>33}, :customer=>true}
   ##################################################
   def self.deep_clone(obj)
+    return obj.clone unless obj.is_a?(Array) || obj.is_a?(Hash)
     obj.clone.tap do |new_obj|
       if new_obj.is_a?(Array)
         new_obj.each_with_index do |val, i|
@@ -30,8 +31,6 @@ class NiceHash
         new_obj.each do |key, val|
           new_obj[key] = deep_clone(val)
         end
-      else
-        new_obj = obj.clone
       end
     end
   end

--- a/lib/nice/hash/delete_nested.rb
+++ b/lib/nice/hash/delete_nested.rb
@@ -27,11 +27,16 @@ class NiceHash
     if keys.size == 1
       hash.delete(nested_key.to_sym)
     else
-      last_key = keys[-1]
-      eval("hash.#{keys[0..(keys.size - 2)].join(".")}.delete(:#{last_key})")
+      parent = hash
+      keys[0..-2].each do |k|
+        sym = k.to_sym
+        return hash unless parent.is_a?(Hash) && parent.key?(sym)
+        parent = parent[sym]
+      end
+      parent.delete(keys[-1].to_sym) if parent.is_a?(Hash)
     end
     return hash
   end
 
- 
+
 end

--- a/lib/nice/hash/diff.rb
+++ b/lib/nice/hash/diff.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class NiceHash
+  ##################################################
+  # Compares two hashes and returns differences with dot-notation paths.
+  #
+  # @param expected [Hash, Array] Expected structure (hash or array of hashes)
+  # @param actual [Hash, Array] Actual structure to compare
+  # @param prefix [String] Internal: current path prefix for recursion
+  #
+  # @return [Hash] Path => { expected: value, got: value } for each difference
+  #
+  # @example
+  #   expected = { user: { address: { city: "Madrid" } } }
+  #   actual   = { user: { address: { city: "London" } } }
+  #   NiceHash.diff(expected, actual)
+  #   #=> { "user.address.city" => { expected: "Madrid", got: "London" } }
+  ##################################################
+  def self.diff(expected, actual, prefix = "")
+    result = {}
+    exp_keys = expected.is_a?(Hash) ? expected.keys : (expected.is_a?(Array) ? (0...expected.size) : nil)
+    act_keys = actual.is_a?(Hash) ? actual.keys : (actual.is_a?(Array) ? (0...actual.size) : nil)
+
+    if expected.is_a?(Hash) && actual.is_a?(Hash)
+      all_keys = (expected.keys + actual.keys).uniq
+      all_keys.each do |k|
+        path = prefix.empty? ? k.to_s : "#{prefix}.#{k}"
+        exp_v = expected[k]
+        act_v = actual[k]
+        if !expected.key?(k)
+          result[path] = { expected: nil, got: act_v }
+        elsif !actual.key?(k)
+          result[path] = { expected: exp_v, got: nil }
+        elsif exp_v.is_a?(Hash) && act_v.is_a?(Hash)
+          result.merge!(diff(exp_v, act_v, path))
+        elsif exp_v.is_a?(Array) && act_v.is_a?(Array)
+          max_len = [exp_v.size, act_v.size].max
+          max_len.times do |i|
+            result.merge!(diff(exp_v[i], act_v[i], "#{path}[#{i}]"))
+          end
+        elsif exp_v != act_v
+          result[path] = { expected: exp_v, got: act_v }
+        end
+      end
+    elsif expected.is_a?(Array) && actual.is_a?(Array)
+      max_len = [expected.size, actual.size].max
+      max_len.times do |i|
+        result.merge!(diff(expected[i], actual[i], prefix.empty? ? "[#{i}]" : "#{prefix}[#{i}]"))
+      end
+    elsif expected != actual
+      result[prefix] = { expected: expected, got: actual } unless prefix.empty?
+    end
+    result
+  end
+end

--- a/lib/nice/hash/flatten_keys.rb
+++ b/lib/nice/hash/flatten_keys.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class NiceHash
+  ##################################################
+  # Flattens a nested hash so keys become dot-notation strings.
+  #
+  # @param hash [Hash] The hash to flatten
+  # @param prefix [String] Internal: current path prefix for recursion
+  #
+  # @return [Hash] Flat hash with string keys like "user.address.city"
+  #
+  # @example
+  #   NiceHash.flatten_keys({ user: { address: { city: "Madrid" } } })
+  #   #=> { "user.address.city" => "Madrid" }
+  ##################################################
+  def self.flatten_keys(hash, prefix = "")
+    return {} unless hash.is_a?(Hash)
+    result = {}
+    hash.each do |k, v|
+      path = prefix.empty? ? k.to_s : "#{prefix}.#{k}"
+      if v.is_a?(Hash)
+        result.merge!(flatten_keys(v, path))
+      else
+        result[path] = v
+      end
+    end
+    result
+  end
+
+  ##################################################
+  # Unflattens a hash with dot-notation keys into a nested hash.
+  #
+  # @param hash [Hash] Flat hash with string keys like "user.address.city"
+  #
+  # @return [Hash] Nested hash
+  #
+  # @example
+  #   NiceHash.unflatten_keys({ "user.address.city" => "Madrid" })
+  #   #=> { user: { address: { city: "Madrid" } } }
+  ##################################################
+  def self.unflatten_keys(hash)
+    return {} unless hash.is_a?(Hash)
+    result = {}
+    hash.each do |key_str, value|
+      keys = key_str.to_s.split(".")
+      keys = keys.map { |k| k.match?(/\A\d+\z/) ? k.to_i : k.to_sym }
+      current = result
+      keys[0..-2].each do |k|
+        current[k] = {} unless current[k].is_a?(Hash)
+        current = current[k]
+      end
+      current[keys[-1]] = value
+    end
+    result
+  end
+end

--- a/lib/nice/hash/set_nested.rb
+++ b/lib/nice/hash/set_nested.rb
@@ -28,27 +28,19 @@ class NiceHash
     if keys.size == 1
       hash[nested_key.to_sym] = value unless only_if_exist and !hash.key?(nested_key.to_sym)
     else
-      exist = true
+      parent = hash
+      keys[0..-2].each do |k|
+        sym = k.to_sym
+        return hash unless parent.is_a?(Hash) && parent.key?(sym)
+        parent = parent[sym]
+      end
+      return hash unless parent.is_a?(Hash)
       if only_if_exist
-        ht = hash.deep_copy
-        keys.each do |k|
-          unless ht.key?(k.to_sym)
-            exist = false
-            break
-          end
-          ht = ht[k.to_sym]
-        end
+        return hash unless parent.key?(keys[-1].to_sym)
       end
-      if !only_if_exist or (only_if_exist and exist)
-        if value.is_a?(String)
-          eval("hash.#{nested_key}='#{value}'")
-        else
-          #todo: consider other kind of objects apart of strings
-          eval("hash.#{nested_key}=#{value}")
-        end
-      end
+      parent[keys[-1].to_sym] = value
     end
     return hash
   end
- 
+
 end

--- a/lib/nice/hash/validate.rb
+++ b/lib/nice/hash/validate.rb
@@ -59,7 +59,7 @@ class NiceHash
     end
     values = values_hash_to_validate
     if pattern_hash.keys.size == get_all_keys(pattern_hash).size and values.keys.size != get_all_keys(values) and
-      pattern_hash.keys.size == pattern_hash.keys.flatten.size # dont't set_values for the case of same_value 
+      pattern_hash.keys.size == pattern_hash.keys.flatten.size # dont't set_values for the case of same_value
       # all patterns on patterns_hash are described on first level, so no same structure than values
       pattern_hash = values.set_values(pattern_hash)
     end
@@ -83,7 +83,9 @@ class NiceHash
         end
 
         if values.keys.include?(key)
-          if value.kind_of?(String) or value.kind_of?(Symbol)
+          if value == :uuid
+            results[key] = false unless StringPattern.valid_uuid?(values[key].to_s)
+          elsif value.kind_of?(String) or value.kind_of?(Symbol)
             if ((StringPattern.optimistic and value.kind_of?(String)) or value.kind_of?(Symbol)) and value.to_s.scan(/^!?\d+-?\d*:.+/).size > 0
               res = StringPattern.validate(pattern: value, text: values[key])
               results[key] = res if res.size > 0
@@ -133,7 +135,7 @@ class NiceHash
                     results[key] << res
                   end
                   if results[key].flatten.size == 0
-                    results.delete(key) 
+                    results.delete(key)
                   end
                 else
                   res = StringPattern.validate(pattern: value, text: values[key])
@@ -213,5 +215,5 @@ class NiceHash
     return results
   end
 
-    
+
 end

--- a/lib/nice_hash.rb
+++ b/lib/nice_hash.rb
@@ -5,6 +5,8 @@ require_relative "nice/hash/add_to_ruby" if SP_ADD_TO_RUBY
 require_relative "nice/hash/change_one_by_one"
 require_relative "nice/hash/compare_structure"
 require_relative "nice/hash/delete_nested"
+require_relative "nice/hash/diff"
+require_relative "nice/hash/flatten_keys"
 require_relative "nice/hash/generate"
 require_relative "nice/hash/get_all_keys"
 require_relative "nice/hash/get_values"

--- a/nice_hash.gemspec
+++ b/nice_hash.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'nice_hash'
-  s.version     = '1.18.7'
+  s.version     = '1.19.0'
   s.summary     = "NiceHash creates hashes following certain patterns so your testing will be much easier. Parse and filter JSON. Perfect to be used in test data factories"
   s.description = "NiceHash creates hashes following certain patterns so your testing will be much easier. Parse and filter JSON. You can easily generate all the hashes you want following the criteria you specify. Many other features coming to Hash class like the methods 'bury' or select_key, access the keys like methods: my_hash.my_key.other_key. You will be able to generate thousands of different hashes just declaring one and test easily APIs based on JSON for example. Perfect to be used in test data factories"
   s.authors     = ["Mario Ruiz"]
@@ -9,8 +9,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["LICENSE","README.md"]
   s.homepage    = 'https://github.com/MarioRuiz/nice_hash'
   s.license       = 'MIT'
+  s.required_ruby_version = '>= 3.0'
   s.post_install_message = "Thanks for installing! Visit us on https://github.com/MarioRuiz/nice_hash"
-  s.add_runtime_dependency 'string_pattern', '~> 2.3', '>= 2.3.0'
+  s.add_runtime_dependency 'string_pattern', '~> 2.4', '>= 2.4.0'
   s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
 end

--- a/spec/nice_hash_additional_specs_spec.rb
+++ b/spec/nice_hash_additional_specs_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "nice_hash"
+
+RSpec.describe "NiceHash additional coverage" do
+  describe "change_one_by_one" do
+    it "handles same_values (multiple keys sharing one pattern)" do
+      pattern = { [:pwd1, :pwd2] => :"3-5:Ln" }
+      wrong = pattern.generate(errors: :min_length)
+      array = NiceHash.change_one_by_one(pattern, wrong)
+      expect(array).to be_an(Array)
+      expect(array.size).to be >= 1
+      array.each do |h|
+        expect(h).to have_key(:pwd1)
+        expect(h).to have_key(:pwd2)
+      end
+    end
+  end
+
+  describe "diff" do
+    it "reports differences in arrays by index" do
+      expected = { items: [{ name: "a" }, { name: "b" }] }
+      actual   = { items: [{ name: "a" }, { name: "x" }] }
+      d = NiceHash.diff(expected, actual)
+      expect(d).to have_key("items[1].name")
+      expect(d["items[1].name"][:expected]).to eq "b"
+      expect(d["items[1].name"][:got]).to eq "x"
+    end
+
+    it "reports when actual has extra key" do
+      expected = { a: 1 }
+      actual   = { a: 1, b: 2 }
+      d = NiceHash.diff(expected, actual)
+      expect(d).to have_key("b")
+      expect(d["b"][:expected]).to be_nil
+      expect(d["b"][:got]).to eq 2
+    end
+
+    it "handles nil values" do
+      expect(NiceHash.diff({ a: nil }, { a: 1 })).to eq("a" => { expected: nil, got: 1 })
+    end
+  end
+
+  describe "flatten_keys" do
+    it "keeps array values as leaves" do
+      h = { user: { tags: %w[a b c] } }
+      flat = NiceHash.flatten_keys(h)
+      expect(flat).to eq("user.tags" => %w[a b c])
+    end
+
+    it "returns empty hash for empty hash" do
+      expect(NiceHash.flatten_keys({})).to eq({})
+    end
+  end
+
+  describe "unflatten_keys" do
+    it "returns empty hash for empty hash" do
+      expect(NiceHash.unflatten_keys({})).to eq({})
+    end
+
+    it "handles numeric key segments" do
+      flat = { "a.0.b" => 1 }
+      expect(NiceHash.unflatten_keys(flat)).to eq({ a: { 0 => { b: 1 } } })
+    end
+  end
+
+  describe "validate" do
+    it "returns error hash for invalid pattern_hash type" do
+      result = NiceHash.validate("not a hash", { a: 1 })
+      expect(result).to eq({ error: :error })
+    end
+  end
+
+  describe "compare_structure with patterns" do
+    it "validates values against patterns when patterns given" do
+      structure = [{ name: "x", zip: "12345" }]
+      replica_ok = [{ name: "Peter", zip: "90210" }]
+      replica_bad_zip = [{ name: "Jane", zip: "bad" }]
+      patterns = { zip: /\A\d{5}\z/ }
+      expect(NiceHash.compare_structure(structure, replica_ok, false, patterns)).to be true
+      expect(NiceHash.compare_structure(structure, replica_bad_zip, false, patterns)).to be false
+    end
+  end
+
+  describe "set_nested" do
+    it "does not set when only_if_exist is true and full path does not exist" do
+      hash = { a: { b: "original" } }
+      result = NiceHash.set_nested(hash, "a.c.x", "new", true)
+      expect(result).to eq(hash)
+      expect(hash.dig(:a, :c)).to be_nil
+    end
+  end
+
+  describe "delete_nested" do
+    it "returns hash unchanged when nested path does not exist" do
+      hash = { a: { b: "keep" } }
+      result = NiceHash.delete_nested(hash, "a.x.y")
+      expect(result).to eq(hash)
+      expect(hash[:a][:b]).to eq "keep"
+    end
+  end
+
+  describe "generate" do
+    it "returns empty hash for empty pattern hash" do
+      expect(NiceHash.generate({})).to eq({})
+    end
+  end
+
+  describe "Hash#has_rkey?" do
+    it "returns true when key matches string (substring)" do
+      h = { address: 1, other: 2 }
+      expect(h.has_rkey?("addr")).to be true
+    end
+
+    it "returns true when key matches symbol" do
+      h = { my_key: 1 }
+      expect(h.has_rkey?(:my_key)).to be true
+    end
+
+    it "returns true when key matches regexp" do
+      h = { user_name: 1, user_age: 2 }
+      expect(h.has_rkey?(/^user_/)).to be true
+    end
+
+    it "returns false when no key matches" do
+      h = { foo: 1 }
+      expect(h.has_rkey?("bar")).to be false
+    end
+  end
+end

--- a/spec/nice_hash_features_spec.rb
+++ b/spec/nice_hash_features_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "nice_hash"
+
+RSpec.describe "NiceHash new features" do
+  describe "generate_n" do
+    it "returns n different hashes" do
+      pattern = { name: :"5:L", age: 18..99 }
+      hashes = NiceHash.generate_n(pattern, 3)
+      expect(hashes.size).to eq 3
+      hashes.each { |h| expect(h).to have_key(:name); expect(h).to have_key(:age) }
+      expect(hashes.map { |h| h[:name] }.uniq.size).to be >= 1
+    end
+
+    it "works via Hash#generate_n" do
+      pattern = { id: :"3:N" }
+      hashes = pattern.generate_n(2)
+      expect(hashes.size).to eq 2
+      expect(hashes.first).to have_key(:id)
+    end
+  end
+
+  describe "diff" do
+    it "returns empty hash when hashes are equal" do
+      h = { a: 1, b: { c: 2 } }
+      expect(NiceHash.diff(h, h)).to eq({})
+      expect(h.diff(h)).to eq({})
+    end
+
+    it "returns path and expected/got for scalar difference" do
+      expected = { user: { address: { city: "Madrid" } } }
+      actual   = { user: { address: { city: "London" } } }
+      expect(NiceHash.diff(expected, actual)).to eq(
+        "user.address.city" => { expected: "Madrid", got: "London" }
+      )
+    end
+
+    it "reports missing key in actual" do
+      expected = { a: 1, b: 2 }
+      actual   = { a: 1 }
+      expect(NiceHash.diff(expected, actual)).to include("b" => { expected: 2, got: nil })
+    end
+
+    it "works via Hash#diff" do
+      expect({ x: 1 }.diff({ x: 2 })).to eq("x" => { expected: 1, got: 2 })
+    end
+  end
+
+  describe "string_pattern 2.4 integration" do
+    it "generates UUID v4 when value is :uuid" do
+      pattern = { id: :uuid }
+      h = NiceHash.generate(pattern)
+      expect(h[:id]).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i)
+    end
+
+    it "validates UUID with :uuid pattern" do
+      pattern = { id: :uuid }
+      expect(pattern.validate(nil, { id: "550e8400-e29b-41d4-a716-446655440000" })).to eq({})
+      expect(pattern.validate(nil, { id: "not-a-uuid" })).to eq({ id: false })
+    end
+
+    it "generate with seed: produces reproducible hash" do
+      pattern = { name: :"5:L", age: 10..20 }
+      a = NiceHash.generate(pattern, nil, seed: 42)
+      b = NiceHash.generate(pattern, nil, seed: 42)
+      expect(a).to eq(b)
+    end
+  end
+
+  describe "flatten_keys and unflatten_keys" do
+    it "flattens nested hash to dot-notation keys" do
+      h = { user: { address: { city: "Madrid" } } }
+      expect(NiceHash.flatten_keys(h)).to eq("user.address.city" => "Madrid")
+    end
+
+    it "unflattens dot-notation keys to nested hash" do
+      flat = { "user.address.city" => "Madrid" }
+      expect(NiceHash.unflatten_keys(flat)).to eq(user: { address: { city: "Madrid" } })
+    end
+
+    it "round-trips flatten and unflatten" do
+      h = { a: 1, b: { c: 2, d: { e: 3 } } }
+      flat = NiceHash.flatten_keys(h)
+      expect(NiceHash.unflatten_keys(flat)).to eq(h)
+    end
+
+    it "works via Hash instance methods" do
+      h = { foo: { bar: 42 } }
+      expect(h.flatten_keys).to eq("foo.bar" => 42)
+      expect({ "foo.bar" => 42 }.unflatten_keys).to eq(foo: { bar: 42 })
+    end
+  end
+end

--- a/spec/nice_hash_missing_specs_spec.rb
+++ b/spec/nice_hash_missing_specs_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "nice_hash"
+
+RSpec.describe "NiceHash missing coverage" do
+  describe "transtring" do
+    it "translates nested hash to dot-separated string" do
+      expect(NiceHash.transtring({ uno: { dos: :tres } })).to eq "uno.dos.tres"
+    end
+
+    it "handles single-level hash" do
+      expect(NiceHash.transtring({ foo: :bar })).to eq "foo.bar"
+    end
+  end
+
+  describe "get_all_keys" do
+    it "gets all keys from hash with nested arrays of hashes" do
+      h = { a: 1, b: [{ c: 2 }, { d: 3 }] }
+      expect(NiceHash.get_all_keys(h)).to match_array [:a, :b, :c, :d]
+    end
+  end
+
+  describe "String#json" do
+    it "returns empty hash for invalid JSON" do
+      expect("not json at all".json).to eq({})
+    end
+
+    it "returns parsed structure when no keys given" do
+      expect('{"a":1,"b":2}'.json).to eq({ a: 1, b: 2 })
+    end
+
+    it "returns empty hash for one key that does not exist" do
+      expect('{"a":1}'.json(:missing)).to eq({})
+    end
+  end
+
+  describe "Array#json" do
+    it "returns empty hash for empty array" do
+      expect([].json(:id)).to eq({})
+    end
+  end
+
+  describe "nice_filter" do
+    it "returns only present keys when some keys are missing" do
+      my_hash = { a: 1, b: { c: 2 } }
+      result = NiceHash.nice_filter(my_hash, [:a, :'b.c', :'b.missing.x'])
+      expect(result).to eq({ a: 1, b: { c: 2 } })
+    end
+
+    it "handles array of hashes" do
+      arr = [{ name: "Peter", age: 33 }, { name: "Jane", age: 44 }]
+      result = NiceHash.nice_filter(arr, [:name])
+      expect(result).to eq([{ name: "Peter" }, { name: "Jane" }])
+    end
+  end
+
+  describe "Hash#respond_to? with method_missing keys" do
+    it "returns true for existing key as method" do
+      h = { address: "Madrid" }
+      expect(h.respond_to?(:address)).to be true
+    end
+
+    it "returns true for existing key with underscore prefix" do
+      h = { display: true }
+      expect(h.respond_to?(:_display)).to be true
+    end
+
+    it "returns false for non-existing key" do
+      h = { address: "Madrid" }
+      expect(h.respond_to?(:nonexistent)).to be false
+    end
+  end
+
+  describe "Array#respond_to? with method_missing keys" do
+    it "returns true when key exists in any hash element" do
+      arr = [{ name: "Peter" }, { name: "Jane" }]
+      expect(arr.respond_to?(:name)).to be true
+    end
+
+    it "returns false when key exists in no hash element" do
+      arr = [{ name: "Peter" }]
+      expect(arr.respond_to?(:missing_key)).to be false
+    end
+  end
+end

--- a/spec/nice_hash_set_nested_delete_nested_spec.rb
+++ b/spec/nice_hash_set_nested_delete_nested_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "nice_hash"
+
+RSpec.describe NiceHash, "set_nested and delete_nested (no eval)" do
+  it "set_nested does not interpret malicious key or value as code" do
+    hash = { a: { b: "safe" } }
+    # Keys/values that would be dangerous if passed to eval
+    NiceHash.set_nested(hash, "a.b", "'; system('echo pwned'); '")
+    expect(hash[:a][:b]).to eq "'; system('echo pwned'); '"
+  end
+
+  it "delete_nested does not interpret malicious path as code" do
+    hash = { a: { b: "v" } }
+    NiceHash.delete_nested(hash, "a.b'); puts 'pwned'; #")
+    expect(hash).to eq({ a: { b: "v" } })
+  end
+end


### PR DESCRIPTION
Security:
- Replace eval in set_nested and delete_nested with iterative traversal

Added:
- generate_n(n), diff, flatten_keys, unflatten_keys
- :uuid pattern and seed: for reproducible generate (string_pattern 2.4)
- respond_to_missing? for Hash and Array
- CHANGELOG, docs/STRING_PATTERN_2.4_INTEGRATION.md
- Gemfile.lock in .gitignore; required_ruby_version >= 3.0; Travis 3.2/3.3
- Specs for new and missing coverage

Fixed:
- deep_clone for non-Array/non-Hash
- generate string_set_not_allowed passing sp_opts to inner StringPattern call